### PR TITLE
Weathermap fix for local rrdcached users and cron fix

### DIFF
--- a/lib/datasources/WeatherMapDataSource_rrd.php
+++ b/lib/datasources/WeatherMapDataSource_rrd.php
@@ -207,10 +207,10 @@ class WeatherMapDataSource_rrd extends WeatherMapDataSource
         $args = array();
         
         // rrdcached Support: strip "./" from Data Source
-        if ($map->daemon)
+/*        if ($map->daemon)
         {
             $rrdfile = trim($rrdfile,"^./"); 
-        }
+        } */
         
         $args[] = "fetch";
         $args[] = $rrdfile;

--- a/map-poller.php
+++ b/map-poller.php
@@ -55,35 +55,35 @@ $config = json_decode(`./config_to_json.php`, true);
 // Change to directory that map-poller is in.
 chdir(__DIR__);
 
-if (is_dir($conf_dir)) 
-{                             
-    if ($dh = opendir($conf_dir)) 
-    {                  
-        while (($file = readdir($dh)) !== false) 
+if (is_dir($conf_dir))
+{
+    if ($dh = opendir($conf_dir))
+    {
+        while (($file = readdir($dh)) !== false)
         {
             if ("." != $file && ".." != $file && ".htaccess" != $file && "index.php" != $file)
-            {                                                                                 
+            {
                 $cmd = "php ./weathermap.php --config $conf_dir/$file --base-href $basehref";
-                                                                                                
-                if (!empty($config['rrdcached']))                                            
-                {                                                                            
-                    $cmd = $cmd." --daemon ".$config['rrdcached']." --chdir ''";         
-                }                                                                            
-                else                                                                         
-                {                                                                         
-                    $cmd = $cmd." --chdir ".$config['rrd_dir'];                          
-                }                                                                            
-                                                                                                
-                $fp = popen($cmd, 'r');                                                      
-                                                                                                
-                while (!feof($fp)) 
-                {                                                         
-                    $read = fgets($fp);                                                  
-                    echo $read;                                                          
-                }                                                                            
-                pclose($fp);                                                                 
-            }                                                                                    
-        }                                                                                   
-    }                                                                                           
-}                                                                                                   
+
+                if (!empty($config['rrdcached']))
+                {
+                    $cmd = $cmd." --daemon ".$config['rrdcached']." --chdir ''";
+                }
+                else
+                {
+                    $cmd = $cmd." --chdir ".$config['rrd_dir'];
+                }
+
+                $fp = popen($cmd, 'r');
+
+                while (!feof($fp))
+                {
+                    $read = fgets($fp);
+                    echo $read;
+                }
+                pclose($fp);
+            }
+        }
+    }
+}
 ?>

--- a/map-poller.php
+++ b/map-poller.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 // Copyright (C) 2013 Neil Lathwood neil@lathwood.co.uk

--- a/map-poller.php
+++ b/map-poller.php
@@ -67,7 +67,14 @@ if (is_dir($conf_dir))
 
                 if (!empty($config['rrdcached']))
                 {
-                    $cmd = $cmd." --daemon ".$config['rrdcached']." --chdir ''";
+                    if (str_contains($config['rrdcached'], 'unix'))
+                    {
+                        $cmd = $cmd." --daemon ".$config['rrdcached'];
+                    }
+                    else
+                    {
+                        $cmd = $cmd." --daemon ".$config['rrdcached']." --chdir ''";
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
The last commit in librenms-plugins https://github.com/librenms-plugins/Weathermap/pull/82 did break some things I'm trying to fix.
- The env path at the start of map-poller.php is missing, so cron cannot call the file anymore
- The fix for remote rrdcached breaks local rrdcached installs

I deal with both cases separately in map-poller, although I'm not sure how to do it in WeatherMapDataSource_rrd.php
Also, I don't want my PR to revert what you did for rrdcached remote installs so I PR here instead of in librenms-plugins repo.

Can you please try this, so we could make both installs work?